### PR TITLE
Issue 3  display total time

### DIFF
--- a/JiraWorklogSubmitter/JiraWorklogSubmitter/Pages/Index.razor
+++ b/JiraWorklogSubmitter/JiraWorklogSubmitter/Pages/Index.razor
@@ -46,13 +46,21 @@ else
                     {
                         <tr>
                             <td>
-                                <input value="@jiraWorklogEntry.Ticket" placeholder="CTS-302" @onchange="@(async e => { jiraWorklogEntry.Ticket = e.Value.ToString(); await GetJiraTicketSummaryAsync(jiraWorklogEntry); })" />
+                                <input value="@jiraWorklogEntry.Ticket" placeholder="CTS-302" @onchange="@(async e =>
+                                                                                                           {
+                                                                                                               jiraWorklogEntry.Ticket = e.Value.ToString();
+                                                                                                               await GetJiraTicketSummaryAsync(jiraWorklogEntry);
+                                                                                                           })" />
                             </td>
                             <td>
                                 <InputText @bind-Value="jiraWorklogEntry.Summary" readonly disabled placeholder="Summary" tabindex="-1" />
                             </td>
                             <td>
-                                <input value="@jiraWorklogEntry.TimeSpent" placeholder="1d 2h 3m" @onchange="@(e => { jiraWorklogEntry.TimeSpent = e.Value.ToString(); UpdateTotalTime(); })" />
+                                <input value="@jiraWorklogEntry.TimeSpent" placeholder="1d 2h 3m" @onchange="@(e =>
+                                                                                                               {
+                                                                                                                   jiraWorklogEntry.TimeSpent = e.Value.ToString();
+                                                                                                                   UpdateTotalTime();
+                                                                                                               })" />
                             </td>
                             <td style="display:flex; align-items: stretch; flex: 0 0 50%;">
                                 <InputTextArea @bind-Value="jiraWorklogEntry.Comment" placeholder="Fixed things" spellcheck="true" />
@@ -61,7 +69,11 @@ else
                                 <button type="button"
                                         class="btn btn-danger"
                                         tabindex="-1"
-                                        @onclick="@(e => DeleteEntry(jiraWorklogEntry))">
+                                        @onclick="@(e =>
+                                                    {
+                                                        DeleteEntry(jiraWorklogEntry);
+                                                        UpdateTotalTime();
+                                                    })">
                                     <i class="oi oi-circle-x"></i>
                                     &nbsp;Remove
                                 </button>
@@ -73,7 +85,9 @@ else
                         <tr>
                             <td></td>
                             <td></td>
-                            <td></td>
+                            <td>
+                                <InputText @bind-Value="_totalTimeSpent" readonly disabled tabindex="-1" />
+                            </td>
                             <td></td>
                             <td></td>
                         </tr>
@@ -114,7 +128,7 @@ else
 
 @code {
     private readonly ICollection<JiraWorklogEntry> _jiraWorklogEntries = new List<JiraWorklogEntry>() { new JiraWorklogEntry() };
-    private TimeSpan _totalTimeSpan = new TimeSpan();
+    private string _totalTimeSpent = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -158,7 +172,7 @@ else
         var regex = new Regex(patternCombined);
 
         var allTimeStrings = _jiraWorklogEntries.Select(worklogEntry => worklogEntry.TimeSpent).ToList();
-        _totalTimeSpan = new TimeSpan(); // Clear the current value since we are going to build a new one
+        var totalTimeSpan = new TimeSpan(); // Clear the current value since we are going to build a new one
 
         foreach (var timeString in allTimeStrings)
         {
@@ -169,12 +183,14 @@ else
                 int.TryParse(match.Groups["hour"].Value, out var hour);
                 int.TryParse(match.Groups["minute"].Value, out var minute);
                 var newTimeSpan = new TimeSpan(day, hour, minute);
-                _totalTimeSpan = _totalTimeSpan.Add(newTimeSpan);
+                totalTimeSpan = totalTimeSpan.Add(newTimeSpan);
             }
             else
             {
                 Console.WriteLine($"No match on {timeString}");
             }
         }
+
+        _totalTimeSpent = totalTimeSpan.ToString();
     }
 }

--- a/JiraWorklogSubmitter/JiraWorklogSubmitter/Pages/Index.razor
+++ b/JiraWorklogSubmitter/JiraWorklogSubmitter/Pages/Index.razor
@@ -4,6 +4,7 @@
 @using JiraWorklogSubmitter.Data
 @using JiraWorklogSubmitter.Services.Interfaces
 @using Microsoft.Extensions.Options
+@using System.Text.RegularExpressions
 @inject ITimeEntryService TimeEntryService
 @inject IOptions<JiraSettings> JiraSettings
 
@@ -41,8 +42,8 @@ else
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var jiraWorklogEntry in _jiraWorklogEntries)
-                        {
+                    @foreach (var jiraWorklogEntry in _jiraWorklogEntries)
+                    {
                         <tr>
                             <td>
                                 <input value="@jiraWorklogEntry.Ticket" placeholder="CTS-302" @onchange="@(async e => { jiraWorklogEntry.Ticket = e.Value.ToString(); await GetJiraTicketSummaryAsync(jiraWorklogEntry); })" />
@@ -51,7 +52,7 @@ else
                                 <InputText @bind-Value="jiraWorklogEntry.Summary" readonly disabled placeholder="Summary" tabindex="-1" />
                             </td>
                             <td>
-                                <InputText @bind-Value="jiraWorklogEntry.TimeSpent" placeholder="1d 2h 3m" />
+                                <input value="@jiraWorklogEntry.TimeSpent" placeholder="1d 2h 3m" @onchange="@(e => { jiraWorklogEntry.TimeSpent = e.Value.ToString(); UpdateTotalTime(); })" />
                             </td>
                             <td style="display:flex; align-items: stretch; flex: 0 0 50%;">
                                 <InputTextArea @bind-Value="jiraWorklogEntry.Comment" placeholder="Fixed things" spellcheck="true" />
@@ -66,8 +67,17 @@ else
                                 </button>
                             </td>
                         </tr>
-                        }
+                    }
                     </tbody>
+                    <tfoot>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
         </div>
@@ -104,6 +114,7 @@ else
 
 @code {
     private readonly ICollection<JiraWorklogEntry> _jiraWorklogEntries = new List<JiraWorklogEntry>() { new JiraWorklogEntry() };
+    private TimeSpan _totalTimeSpan = new TimeSpan();
 
     protected override async Task OnInitializedAsync()
     {
@@ -132,5 +143,38 @@ else
     {
         var result = await TimeEntryService.GetJiraTicketSummaryAsync(jiraWorklogEntry.Ticket);
         jiraWorklogEntry.Summary = result;
+    }
+
+    private void UpdateTotalTime()
+    {
+        //TODO: Need to handle the fact that 8h is considered 1d to Jira, so maybe manipulate the time span to show that? Might be company based though...
+
+        const string patternDay = @"((?<day>\d+)\s?[dD])";
+        const string patternHour = @"((?<hour>\d+)\s?[hH])";
+        const string patternMinute = @"((?<minute>\d+)\s?[mM])";
+
+        var patternCombined = $@"{patternDay}?\s?{patternHour}?\s?{patternMinute}?";
+
+        var regex = new Regex(patternCombined);
+
+        var allTimeStrings = _jiraWorklogEntries.Select(worklogEntry => worklogEntry.TimeSpent).ToList();
+        _totalTimeSpan = new TimeSpan(); // Clear the current value since we are going to build a new one
+
+        foreach (var timeString in allTimeStrings)
+        {
+            var match = regex.Match(timeString);
+            if (match.Success)
+            {
+                int.TryParse(match.Groups["day"].Value, out var day);
+                int.TryParse(match.Groups["hour"].Value, out var hour);
+                int.TryParse(match.Groups["minute"].Value, out var minute);
+                var newTimeSpan = new TimeSpan(day, hour, minute);
+                _totalTimeSpan = _totalTimeSpan.Add(newTimeSpan);
+            }
+            else
+            {
+                Console.WriteLine($"No match on {timeString}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #3 Now displays the total time in the table footer

When a time spent field, or a work log is removed, then it will use regex to parse out "1d 2h 3m" type strings from all the work logs and add them up into a timespan and convert it to a string to be displayed. Blazor doesn't like binding to a timeSpan.ToString() so this seemed like the best method